### PR TITLE
Moving rake into :test group as it only runs tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "rake"
 gem "nats", ">= 0.5.0.beta.12", "< 0.6"
 gem "vcap_common", git: "https://github.com/cloudfoundry/vcap-common.git"
 gem "aws-sdk", require: false
@@ -8,6 +7,7 @@ gem "steno"
 gem "httparty"
 
 group :test do
+  gem "rake"
   gem "rspec"
   gem "ci_reporter"
   gem "timecop"


### PR DESCRIPTION
This allows collector pre-packaging script to run properly in cf-release.

Currently it does this: https://gist.github.com/grenzr/8670267

If rake is moved into test group, then pre-packaging will work as the rake problem is removed:

```
grenzr-mac:collector (rake_gemfile_move*) $ BUNDLE_WITHOUT=development:test bundle package --all
Using addressable (2.3.5)
Using json (1.7.7)
Using nokogiri (1.5.6)
Using uuidtools (2.1.3)
Using aws-sdk (1.8.3.1)
Using cookiejar (0.3.0)
Using daemons (1.1.9)
Using eventmachine (1.0.3)
Using em-socksify (0.3.0)
Using http_parser.rb (0.6.0)
Using em-http-request (1.1.2)
Using msgpack (0.5.5)
Using yajl-ruby (1.1.0)
Using fluent-logger (0.4.6)
Using hashie (1.2.0)
Using multi_json (1.0.4)
Using multi_xml (0.5.4)
Using rack (1.5.2)
Using rack-mount (0.8.3)
Using grape (0.2.1.1)
Using httparty (0.11.0)
Using httpclient (2.3.4.1)
Using json_pure (1.8.1)
Using membrane (0.0.2)
Using mime-types (2.0)
Using multipart-post (2.0.0)
Using thin (1.6.1)
Using nats (0.5.0.beta.12)
Using posix-spawn (0.3.8)
Using squash_ruby (1.4.0)
Using steno (1.1.0)
Using vmstat (2.1.0)
Using vcap_common (3.0.0) from https://github.com/cloudfoundry/vcap-common.git (at master)
Using bundler (1.5.2)
Your bundle is complete!
Gems in the groups development and test were not installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
Updating files in vendor/cache
  * addressable-2.3.5.gem
  * json-1.7.7.gem
  * nokogiri-1.5.6.gem
  * uuidtools-2.1.3.gem
  * aws-sdk-1.8.3.1.gem
  * cookiejar-0.3.0.gem
  * daemons-1.1.9.gem
  * eventmachine-1.0.3.gem
  * em-socksify-0.3.0.gem
  * http_parser.rb-0.6.0.gem
  * em-http-request-1.1.2.gem
  * msgpack-0.5.5.gem
  * yajl-ruby-1.1.0.gem
  * fluent-logger-0.4.6.gem
  * hashie-1.2.0.gem
  * multi_json-1.0.4.gem
  * multi_xml-0.5.4.gem
  * rack-1.5.2.gem
  * rack-mount-0.8.3.gem
  * grape-0.2.1.1.gem
  * httparty-0.11.0.gem
Moving rake into :test group as it only runs tests
  * httpclient-2.3.4.1.gem
  * json_pure-1.8.1.gem
  * membrane-0.0.2.gem
  * mime-types-2.0.gem
  * multipart-post-2.0.0.gem
  * thin-1.6.1.gem
  * nats-0.5.0.beta.12.gem
  * posix-spawn-0.3.8.gem
  * squash_ruby-1.4.0.gem
  * steno-1.1.0.gem
  * vmstat-2.1.0.gem
Cloning into '/Users/rgrenz/work/bskyb/collector/vendor/cache/vcap-common-c731a3eed1bb'...
done.
```
