### PR TITLE
Specify host of cf_metrics as URL

### DIFF
--- a/lib/collector/historian/cf_metrics.rb
+++ b/lib/collector/historian/cf_metrics.rb
@@ -31,7 +31,7 @@ module Collector
       def send_metrics(metric_name, metric_data)
         Config.logger.debug("Sending metrics to cf-metrics: [#{metric_data.inspect}]")
         body = Yajl::Encoder.encode(metric_data)
-        response = @http_client.put("https://#{@api_host}/metrics/#{metric_name}/values", body: body, headers: {"Content-type" => "application/json"})
+        response = @http_client.put("#{@api_host}/metrics/#{metric_name}/values", body: body, headers: {"Content-type" => "application/json"})
         if response.success?
           Config.logger.info("collector.emit-cfmetrics.success", number_of_metrics: 1, lag_in_seconds: 0)
         else

--- a/spec/unit/collector/historian/cf_metrics_spec.rb
+++ b/spec/unit/collector/historian/cf_metrics_spec.rb
@@ -45,7 +45,7 @@ describe Collector::Historian::CfMetrics do
     let(:fake_http_client) { FakeHttpClient.new }
     let(:cf_metrics_historian) do
       Timecop.freeze(Time.at(time)) do
-        described_class.new("api.metrics.example.com", fake_http_client)
+        described_class.new("https://api.metrics.example.com", fake_http_client)
       end
     end
     let(:time) { Time.now.to_i }


### PR DESCRIPTION
This commit enables users to configure the URL of the remote endpoint of
the cf_metrics historian more flexibly.
