### PR TITLE
Reset Collector::Config after each test-case run.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,19 +10,24 @@ require "timecop"
 
 require "collector/config"
 require "cf_message_bus/mock_message_bus"
-Collector::Config.configure(
-  "logging" => {"level" => ENV["DEBUG"] ? "debug2" : "fatal"},
-  "tsdb" => {},
-  "intervals" => {}
-)
+
 
 require "collector"
 
+
+def set_collector_base_config
+  Collector::Config.configure(
+    "logging" => {"level" => ENV["DEBUG"] ? "debug2" : "fatal"},
+    "tsdb" => {},
+    "intervals" => {}
+  )
+end
 
 RSpec.configure do |c|
   c.before do
     allow(EventMachine).to receive(:defer).and_yield
     Collector::Handler.instance_map = {}
+    set_collector_base_config
   end
 end
 


### PR DESCRIPTION
Previously, Collector::Config is global while running test cases, the lack of resetting Collector::Config after each test case can cause failure in this case:
Test cases run randomly,when test case1 runs last in spec/unit/collector/historian_spec.rb, Collector::Config.graphite is assigned.
Then running test case2 in spec/unit/collector_spec.rb,there is an expection:
EventMachine.should_receive(:connect).with("dummy", 14242, Collector::TsdbConnection),
because Collector::Config.graphite isn't nill, it triggers EventMachine.connect of Collector::Historian::Graphite:code1=>code2=>code3=>code4
This causes the failure:

```
 Collector::Collector local metrics should send nats latency rolling metric
     Failure/Error: create_fake_collector do |collector, _, _|
       EventMachine received :connect with unexpected arguments
         expected: ("dummy", 14242, Collector::TsdbConnection)
              got: ("graphite.host.domain.com", 1234, Collector::GraphiteConnection)
     # ./lib/collector/historian/graphite.rb:10:in `initialize'
     # ./lib/collector/historian.rb:34:in `new'
     # ./lib/collector/historian.rb:34:in `build'
     # ./lib/collector.rb:37:in `initialize'
     # ./spec/unit/collector_spec.rb:239:in `send_local_metrics'
     # ./spec/unit/collector_spec.rb:256:in `block (3 levels) in <top (required)>'
```

The sulution is reset Collector::Config after each test case.
