### PR TITLE
Fix typo in tcp_connection.rb

### DIFF
--- a/lib/collector/tcp_connection.rb
+++ b/lib/collector/tcp_connection.rb
@@ -1,5 +1,5 @@
 module Collector
-  # TSDB connection for sending metrics
+  # TCP connection for sending metrics
   class TCPConnection < EventMachine::Connection
     def initialize(logger_name)
       @logger_name = logger_name


### PR DESCRIPTION
Comment for TCPConnection class is being "TSDB connection for sending metrics", it should be "TCP connection for sending metrics".