### PR TITLE
Use job_name instead of IP address in graphite metrics

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -88,6 +88,7 @@ module Collector
         instances[message["host"].split(":").first] = {
           :host => message["host"],
           :index => message["index"],
+          :job_name => message['job_name'],
           :credentials => message["credentials"],
           :timestamp => Time.now.to_i
         }
@@ -122,12 +123,13 @@ module Collector
     def fetch_varz
       fetch(:varz) do |resp, job, instance|
         index = instance[:index]
+        job_name = instance[:job_name]
         varz = Yajl::Parser.parse(resp)
         now = Time.now.to_i
 
         handler = Handler.handler(@historian, job)
         Config.logger.debug("collector.job.process", job: job, handler: handler.class.name)
-        ctx = HandlerContext.new(index, now, varz)
+        ctx = HandlerContext.new(index, now, varz, job_name)
         handler.do_process(ctx)
       end
     end

--- a/lib/collector/handler.rb
+++ b/lib/collector/handler.rb
@@ -6,15 +6,17 @@ module Collector
     attr_reader :index
     attr_reader :now
     attr_reader :varz
+    attr_reader :job_name
 
-    def initialize(index, now, varz)
+    def initialize(index, now, varz, job_name = nil)
       @index = index
       @now = now
       @varz = varz
+      @job_name = job_name
     end
 
     def ==(other)
-      other.index == index && other.now == now && other.varz == varz
+      other.index == index && other.now == now && other.varz == varz && other.job_name == job_name
     end
   end
 
@@ -121,7 +123,7 @@ module Collector
 
       tags.merge!(additional_tags(context))
       tags.merge!(Components.get_job_tags(@job))
-      tags.merge!(job: @job, index: context.index)
+      tags.merge!(job: @job, index: context.index, job_name: context.job_name)
       tags.merge!(name: "#{@job}/#{context.index}", deployment: Config.deployment_name)
 
       @historian.send_data({

--- a/lib/collector/historian/graphite.rb
+++ b/lib/collector/historian/graphite.rb
@@ -24,21 +24,23 @@ module Collector
 
       def get_metrics_name(properties)
         # Given a properties hash like so
-        # {:key=>"cpu_load_avg", :timestamp=>1394801347, :value=>0.25, :tags=>{:ip=>"172.30.5.74", :role=>"core", :job=>"CloudController", :index=>0, :name=>"CloudController/0", :deployment=>"CF"}}
+        # {:key=>"cpu_load_avg", :timestamp=>1394801347, :value=>0.25, :tags=>{:ip=>"172.30.5.74", :role=>"core", :job=>"CloudController", :job_name=>"api_z1", :index=>0, :name=>"CloudController/0", :deployment=>"CF"}}
         # One will get a metrics key like so
-        # CF.CloudController.0.172-30-5-74.cpu_load_avg
+        # CF.api_z1.0.cpu_load_avg
         deployment = properties[:tags][:deployment]
         job = properties[:tags][:job]
+        job_name = properties[:tags][:job_name]
         index = properties[:tags][:index]
         ipField = (properties[:tags][:ip]|| properties[:tags]["ip"])
         ip = ((ipField) ? ipField.gsub(".","-") : "nil" )
         key = properties[:key]
-        unless deployment && job && index && ip && key
+        unless deployment && job && index && key
           Config.logger.error("collector.create-graphite-key.fail: Could not create metrics name from fields tags.deployment, tags.job, tags.index or key.")
           return nil
         end
         key = router_key(properties) if job == "Router"
-        [deployment, job, index, ip, key].join '.'
+        return [deployment, job_name, index, key].join '.' if job_name
+        return [deployment, job, index, ip, key].join '.'
       end
 
       def router_key(properties)

--- a/spec/unit/collector/handler_spec.rb
+++ b/spec/unit/collector/handler_spec.rb
@@ -1,5 +1,24 @@
 require "spec_helper"
 
+describe Collector::HandlerContext do
+
+  describe '#==' do
+    it 'should be equal if index, now, varz, and job_name are equal' do
+      context = Collector::HandlerContext.new(nil, nil, {}, 'jobname')
+      context2 = Collector::HandlerContext.new(nil, nil, {}, 'jobname')
+
+      expect(context).to eq(context2)
+    end
+    it 'should not be equal if job_name is not equal' do
+      context = Collector::HandlerContext.new(nil, nil, {}, 'jobname')
+      context2 = Collector::HandlerContext.new(nil, nil, {})
+
+      expect(context).to_not eq(context2)
+    end
+  end
+
+end
+
 describe Collector::Handler do
   describe "#handler" do
     it "should return the default handler when none registered" do
@@ -47,7 +66,7 @@ describe Collector::Handler do
     describe "sent tags" do
       let(:historian) { double }
       let(:handler) { Collector::Handler.new(historian, "DEA") }
-      let(:context) { Collector::HandlerContext.new(0, nil, {"cpu_load_avg" => "42"}) }
+      let(:context) { Collector::HandlerContext.new(0, nil, {"cpu_load_avg" => "42"}, 'jobname') }
 
       it "adds extra tags when specified" do
         handler.stub(:additional_tags => {foo: "bar"})
@@ -64,6 +83,7 @@ describe Collector::Handler do
           tags: hash_including({
             job: "DEA",
             index: 0,
+            job_name: 'jobname',
             role: "core"
           })
         ))
@@ -79,10 +99,10 @@ describe Collector::Handler do
         key: "some_key",
         timestamp: 10000,
         value: 2,
-        tags: {index: 1, job: "Test", name: "Test/1", deployment: "untitled_dev", foo: "bar"}
+        tags: {index: 1, job: "Test", name: "Test/1", deployment: "untitled_dev", foo: "bar", job_name: 'jobname'}
       )
 
-      context = Collector::HandlerContext.new(1, 10000, {})
+      context = Collector::HandlerContext.new(1, 10000, {}, 'jobname')
       handler = Collector::Handler.handler(historian, "Test")
       handler.send_metric("some_key", 2, context, {foo: "bar"})
     end
@@ -93,10 +113,10 @@ describe Collector::Handler do
         key: "some_key",
         timestamp: 10000,
         value: 2,
-        tags: {index: 1, job: "DEA", name: "DEA/1", deployment: "untitled_dev", role: "core"}
+        tags: {index: 1, job: "DEA", name: "DEA/1", deployment: "untitled_dev", role: "core", job_name: 'jobname'}
       )
 
-      context = Collector::HandlerContext.new(1, 10000, {})
+      context = Collector::HandlerContext.new(1, 10000, {}, 'jobname')
       handler = Collector::Handler.handler(historian, "DEA")
       handler.stub(:additional_tags => {
         job: "foo",

--- a/spec/unit/collector/handlers/cloud_controller_spec.rb
+++ b/spec/unit/collector/handlers/cloud_controller_spec.rb
@@ -10,7 +10,7 @@ describe Collector::Handler::CloudController do
       end
     end
   end
-  let(:context) { Collector::HandlerContext.new(0, now, fixture(:cloud_controller)) }
+  let(:context) { Collector::HandlerContext.new(0, now, fixture(:cloud_controller), 'jobname') }
   let(:handler) { Collector::Handler::CloudController.new(historian, "CloudController") }
 
   it "should register itself as a handler" do
@@ -38,7 +38,8 @@ describe Collector::Handler::CloudController do
         index: 0,
         ip: "10.10.16.13",
         name: "CloudController/0",
-        deployment: "untitled_dev"
+        deployment: "untitled_dev",
+        job_name: 'jobname'
       }
     end
 

--- a/spec/unit/collector/historian/graphite_spec.rb
+++ b/spec/unit/collector/historian/graphite_spec.rb
@@ -11,142 +11,161 @@ describe Collector::Historian::Graphite do
 
   describe "sending data to Graphite" do
     let(:connection) { double('EventMachine connection') }
-    let(:metric_payload) do
-      {
-        key: "some_key",
-        timestamp: 1234568912,
-        value: 2,
-        tags: {
-          :ip => "1.2.3.4",
-          :deployment => "CF",
-          :job => "Blurgh",
-          :index => 0
-        }
-      }
-    end
 
     before do
       EventMachine.stub(:connect).and_return(connection)
     end
 
-    it "converts the properties hash graphite data" do
-      graphite_historian = described_class.new("host", 9999)
-
-      connection.should_receive(:send_data).with("CF.Blurgh.0.1-2-3-4.some_key 2 1234568912\n")
-      graphite_historian.send_data(metric_payload)
-    end
-
-    it "converts the properties hash graphite data even though the type of the ip field is a string" do
-      metric_payload_with_string_type = {
-        key: "some_key",
-        timestamp: 1234568912,
-        value: 2,
-        tags: {
-          "ip" => "1.2.3.4",
-          :deployment => "CF",
-          :job => "Blurgh",
-          :index => 0
+    context 'when the jobname is not set' do
+      it "converts the properties hash graphite data even though the type of the ip field is a string" do
+        metric_payload_with_string_type = {
+          key: "some_key",
+          timestamp: 1234568912,
+          value: 2,
+          tags: {
+            "ip" => "1.2.3.4",
+            :deployment => "CF",
+            :job => "Blurgh",
+            :index => 0
+          }
         }
-      }
-      graphite_historian = described_class.new("host", 9999)
-      connection.should_receive(:send_data).with("CF.Blurgh.0.1-2-3-4.some_key 2 1234568912\n")
-      graphite_historian.send_data(metric_payload_with_string_type)
-    end
-
-
-    it "send the event even if ip tags is missing" do
-      metric_payload_with_string_type = {
-        key: "some_key",
-        timestamp: 1234568912,
-        value: 2,
-        tags: {
-          :deployment => "CF",
-          :job => "Blurgh",
-          :index => 0
-        }
-      }
-      graphite_historian = described_class.new("host", 9999)
-      connection.should_receive(:send_data).with("CF.Blurgh.0.nil.some_key 2 1234568912\n")
-      graphite_historian.send_data(metric_payload_with_string_type)
-    end
-
-    it "Should send router responses status code" do
-      metric_payload_with_string_type = {
-        key: "router.responses.2xx",
-        timestamp: 1234568912,
-        value: 2,
-        tags: {
-          "ip" => "1.2.3.4",
-          :deployment => "CF",
-          :job => "Router",
-          :index => 0
-        }
-      }
-      graphite_historian = described_class.new("host", 9999)
-      connection.should_receive(:send_data).with("CF.Router.0.1-2-3-4.router.responses.2xx 2 1234568912\n")
-      graphite_historian.send_data(metric_payload_with_string_type)
-    end
-
-    it "Should send router reponse status by component " do
-      metric_payload_with_string_type = {
-        key: "router.responses",
-        timestamp: 1234568912,
-        value: 2,
-        tags: {
-          "ip" => "1.2.3.4",
-          :deployment => "CF",
-          :job => "Router",
-          :index => 0,
-          :component => "CC",
-          :status => "2xx"
-        }
-      }
-      graphite_historian = described_class.new("host", 9999)
-      connection.should_receive(:send_data).with("CF.Router.0.1-2-3-4.router.responses.CC.2xx 2 1234568912\n")
-      graphite_historian.send_data(metric_payload_with_string_type)
-    end
-
-    context "when the passed in data is missing a timestamp" do
-      it "uses now" do
         graphite_historian = described_class.new("host", 9999)
-        metric_payload.delete(:timestamp)
-        Timecop.freeze Time.now.to_i do
-          connection.should_receive(:send_data).with("CF.Blurgh.0.1-2-3-4.some_key 2 #{Time.now.to_i}\n")
+        connection.should_receive(:send_data).with("CF.Blurgh.0.1-2-3-4.some_key 2 1234568912\n")
+        graphite_historian.send_data(metric_payload_with_string_type)
+      end
+
+      it "send the event even if ip tags is missing" do
+        metric_payload_with_string_type = {
+          key: "some_key",
+          timestamp: 1234568912,
+          value: 2,
+          tags: {
+            :deployment => "CF",
+            :job => "Blurgh",
+            :index => 0
+          }
+        }
+        graphite_historian = described_class.new("host", 9999)
+        connection.should_receive(:send_data).with("CF.Blurgh.0.nil.some_key 2 1234568912\n")
+        graphite_historian.send_data(metric_payload_with_string_type)
+      end
+    end
+    context 'when the jobname is set' do
+
+      let(:metric_payload) do
+        {
+          key: "some_key",
+          timestamp: 1234568912,
+          value: 2,
+          tags: {
+            :ip => "1.2.3.4",
+            :deployment => "CF",
+            :job => "Blurgh",
+            :index => 0,
+            :job_name => 'jobname'
+          }
+        }
+      end
+
+      it "converts the properties hash graphite data" do
+        graphite_historian = described_class.new("host", 9999)
+
+        connection.should_receive(:send_data).with("CF.jobname.0.some_key 2 1234568912\n")
+        graphite_historian.send_data(metric_payload)
+      end
+
+      describe 'When processing router metrics' do
+        context 'without components' do
+          let(:metric_payload) do
+            {
+              key: "router.responses.2xx",
+              timestamp: 1234568912,
+              value: 2,
+              tags: {
+                :ip => "1.2.3.4",
+                :deployment => "CF",
+                :job => "Router",
+                :index => 0,
+                :job_name => 'router_z0'
+              }
+            }
+          end
+
+          it "Should send router responses status code" do
+            graphite_historian = described_class.new("host", 9999)
+            connection.should_receive(:send_data).with("CF.router_z0.0.router.responses.2xx 2 1234568912\n")
+            graphite_historian.send_data(metric_payload)
+          end
+        end
+
+        context 'with components' do
+          let(:metric_payload) do
+            {
+              key: "router.responses",
+              timestamp: 1234568912,
+              value: 2,
+              tags: {
+                :ip => "1.2.3.4",
+                :deployment => "CF",
+                :job => "Router",
+                :index => 0,
+                :component => "CC",
+                :status => "2xx",
+                :job_name => 'router_z0'
+              }
+            }
+          end
+
+          it "Should send router reponse status by component " do
+            graphite_historian = described_class.new("host", 9999)
+            connection.should_receive(:send_data).with("CF.router_z0.0.router.responses.CC.2xx 2 1234568912\n")
+            graphite_historian.send_data(metric_payload)
+          end
+        end
+      end
+
+      context "when the passed in data is missing a timestamp" do
+        it "uses now" do
+          graphite_historian = described_class.new("host", 9999)
+          metric_payload.delete(:timestamp)
+          Timecop.freeze Time.now.to_i do
+            connection.should_receive(:send_data).with("CF.jobname.0.some_key 2 #{Time.now.to_i}\n")
+            graphite_historian.send_data(metric_payload)
+          end
+        end
+      end
+
+
+      context "when the passed in data has wrongly formatted timestamp" do
+        it "uses now" do
+          graphite_historian = described_class.new("host", 9999)
+
+          metric_payload.update(:timestamp => "BLURGh!!11")
+          Timecop.freeze Time.now.to_i do
+            connection.should_receive(:send_data).with("CF.jobname.0.some_key 2 #{Time.now.to_i}\n")
+            graphite_historian.send_data(metric_payload)
+          end
+        end
+      end
+
+      context "when the value is not a int or float" do
+        it "should log and not do anything" do
+          graphite_historian = described_class.new("host", 9999)
+          metric_payload.update(:value => "BLURGh!!11")
+          ::Collector::Config.logger.should_receive(:error).with("collector.emit-graphite.fail: Value is not a float or int, got: BLURGh!!11")
           graphite_historian.send_data(metric_payload)
         end
       end
-    end
 
-
-    context "when the passed in data has wrongly formatted timestamp" do
-      it "uses now" do
-        graphite_historian = described_class.new("host", 9999)
-
-        metric_payload.update(:timestamp => "BLURGh!!11")
-        Timecop.freeze Time.now.to_i do
-          connection.should_receive(:send_data).with("CF.Blurgh.0.1-2-3-4.some_key 2 #{Time.now.to_i}\n")
+      context "when there is a missing field from the properties" do
+        it "cannot create a metrics key and should log the error" do
+          graphite_historian = described_class.new("host", 9999)
+          metric_payload.delete(:key)
+          ::Collector::Config.logger.should_receive(:error).with("collector.create-graphite-key.fail: Could not create metrics name from fields tags.deployment, tags.job, tags.index or key.")
           graphite_historian.send_data(metric_payload)
         end
       end
-    end
 
-    context "when the value is not a int or float" do
-      it "should log and not do anything" do
-        graphite_historian = described_class.new("host", 9999)
-        metric_payload.update(:value => "BLURGh!!11")
-        ::Collector::Config.logger.should_receive(:error).with("collector.emit-graphite.fail: Value is not a float or int, got: BLURGh!!11")
-        graphite_historian.send_data(metric_payload)
-      end
     end
-
-    context "when there is a missing field from the properties" do
-      it "cannot create a metrics key and should log the error" do
-        graphite_historian = described_class.new("host", 9999)
-        metric_payload.delete(:key)
-        ::Collector::Config.logger.should_receive(:error).with("collector.create-graphite-key.fail: Could not create metrics name from fields tags.deployment, tags.job, tags.index or key.")
-        graphite_historian.send_data(metric_payload)
-      end
-    end
-
   end
 end

--- a/spec/unit/collector_spec.rb
+++ b/spec/unit/collector_spec.rb
@@ -26,6 +26,7 @@ describe Collector::Collector do
         collector.process_component_discovery({
             "type"        => "Test",
             "index"       => 1,
+            'job_name'    => 'jobname',
             "host"        => "test-host:1234",
             "credentials" => ["user", "pass"]
           })
@@ -35,6 +36,7 @@ describe Collector::Collector do
             "test-host" => {
               :host        => "test-host:1234",
               :index       => 1,
+              :job_name    => 'jobname',
               :credentials => ["user", "pass"],
               :timestamp   => 1311979380
             }
@@ -55,6 +57,7 @@ describe Collector::Collector do
         collector.process_component_discovery({
             "type"        => "Test",
             "index"       => 1,
+            'job_name'    => 'jobname',
             "host"        => "test-host-1:1234",
             "credentials" => ["user", "pass"]
           })
@@ -62,6 +65,7 @@ describe Collector::Collector do
         collector.process_component_discovery({
             "type"        => "Test",
             "index"       => 2,
+            'job_name'    => 'jobname',
             "host"        => "test-host-2:1234",
             "credentials" => ["user", "pass"]
           })
@@ -78,6 +82,7 @@ describe Collector::Collector do
             "test-host-2" => {
               :host        => "test-host-2:1234",
               :index       => 2,
+              :job_name    => 'jobname',
               :credentials => ["user", "pass"],
               :timestamp   => 100005
             }
@@ -92,6 +97,7 @@ describe Collector::Collector do
       collector.process_component_discovery(
         "type"        => "Test",
         "index"       => 0,
+        'job_name'    => 'jobname',
         "host"        => "test-host:1234",
         "credentials" => ["user", "pass"]
       )
@@ -122,7 +128,7 @@ describe Collector::Collector do
 
           fetch_varz
 
-          expect(handler).to have_received(:do_process).with(Collector::HandlerContext.new(0, Time.now.to_i, { "foo" => "bar" }))
+          expect(handler).to have_received(:do_process).with(Collector::HandlerContext.new(0, Time.now.to_i, { "foo" => "bar" }, 'jobname'))
         end
       end
     end


### PR DESCRIPTION
Use a new property 'job_name' taken from components' registration
messages and pass it as a tag to handlers.  As soon as components
send this in their registration messages the graphite handler
will use the tag in the metric name instead of the IP address.

We do this because the metrics received from the bosh health monitor
also use the bosh job name (e.g. api_z0). These are a better means to
distinguish jobs with the same index in different AZs than IP
addresses.

Signed-off-by: Marco Voelz <marco.voelz@sap.com>